### PR TITLE
FIX. fixed category vs. dynamic data

### DIFF
--- a/src/listBuilder.js
+++ b/src/listBuilder.js
@@ -32,8 +32,9 @@ var EasyAutocomplete = (function(scope) {
 				for(var i = 0; i < configuration.get("categories").length; i += 1) {
 
 					var builder = convertToListBuilder(configuration.get("categories")[i], data);
-
-					listBuilder.push(builder);
+					if (builder.data){
+						listBuilder.push(builder);
+					}
 				}
 
 			} 


### PR DESCRIPTION
`options.categories` contains a fixed list of categories for the resulting items loaded vía `options.url `(dynamic).
however, when resulting data does not contain items for one of the categories an error is thrown. 
with the following check, no listBuilder is generated for those categories without resulting items for the autocomplete.